### PR TITLE
created mobile layout

### DIFF
--- a/src/components/button/Styles.scss
+++ b/src/components/button/Styles.scss
@@ -1,4 +1,5 @@
 @import '../../styles/utils/colors';
+@import '../../styles/utils/breakpoints';
 
 .submitButton{
   text-align: center;
@@ -14,4 +15,5 @@
   &--inactive{
     background-color: $elephant-paw;
   }
+  
 }

--- a/src/components/learningModule/Styles.scss
+++ b/src/components/learningModule/Styles.scss
@@ -5,6 +5,9 @@
 .learningModule {
     &__header {
         text-align: center;
+        @media only screen and (max-width: $mobile){
+            text-align: left;
+        }
     }
 
     &__title {
@@ -12,11 +15,17 @@
         color: $morning-sky;
         font-weight: 600;
         font-size: 1.5em;
+        @media only screen and (max-width: $mobile){
+            text-align: left;
+        }
     }
 
     &__subHeader{
         @include subheader;
         min-height: 42px;
+        @media only screen and (max-width: $mobile){
+            display: none;
+        }
     }
   
     &__answerArea {
@@ -29,6 +38,9 @@
         @media only screen and (max-width: $tablet) {
             border-radius: unset;
         }
+        @media( max-width: $mobile){
+            background-color: transparent;
+        }
 
     }
 
@@ -37,12 +49,24 @@
         display: grid;
         grid-auto-flow: column;
         grid-gap: 10px;
+
+        @media (max-width: $mobile) {
+            display: flex;
+            flex-direction: column;
+            
+        }
     }
 
     &__submitButtonContainer {
         height: 50px;
         .submitButton {
             float: right;
+        }
+
+        @media (max-width: $mobile){
+            .submitButton {
+                float: none;
+            }
         }
     }
 }

--- a/src/components/navbar/Styles.scss
+++ b/src/components/navbar/Styles.scss
@@ -1,6 +1,14 @@
+@import '../../styles/utils/breakpoints';
+
 #navbarContainer{
   height: 50px;
   background: black;
+
+  @media (max-width: $mobile){
+    display: flex;
+    justify-items: center;
+  }
+
 }
 
 #navbarContent{
@@ -20,5 +28,7 @@
     height: 30px;
     line-height: 40px;
     padding: 10px 15px;
+    
   }
+  
 }

--- a/src/components/selectionBox/Styles.scss
+++ b/src/components/selectionBox/Styles.scss
@@ -1,4 +1,5 @@
 @import '../../styles/utils/colors';
+@import '../../styles//utils/breakpoints';
 
 .selectionBox{
     position: relative;
@@ -13,4 +14,5 @@
     &__image {display: block; width: inherit; padding-bottom: 8px;  }
     &__text {font-size: 1em; font-weight: 600;}
     input { position: absolute; left: 4px;}
+    
   }


### PR DESCRIPTION
Created a mobile layout with the following: 
- Don't display the subheader on each question. 
- White container for the answers is removed.
- Button for answer submission is full-width.
- Center the logo in the navbar
- Align the title to the left.

Wasn't able to arrange the following:
- Answers are arranged in a grid of 2x2 elements.